### PR TITLE
Fix backspace crash, handle more chatbox use-cases

### DIFF
--- a/src/main/java/io/github/apace100/smwyg/mixin/TextFieldWidgetMixin.java
+++ b/src/main/java/io/github/apace100/smwyg/mixin/TextFieldWidgetMixin.java
@@ -182,8 +182,6 @@ public abstract class TextFieldWidgetMixin implements ItemSharingTextFieldWidget
     private void handleOverwrite(int start, int end, int replacementLength) {
         // when nothing is highlighted, start == end
 
-        Log.info(LogCategory.GENERAL, "erasing [%d,%d)", start, end);
-
         boolean isErasingEntireTag = start <= insertedIndex && end >= insertedIndex + insertedLength;
         // selecting a range inside the tag is not typically possible, but handle it anyway
         boolean isStartInside = start > insertedIndex && start < insertedIndex + insertedLength;
@@ -194,7 +192,6 @@ public abstract class TextFieldWidgetMixin implements ItemSharingTextFieldWidget
             reset();
         } else if (isErasingBefore) {
             int offset = replacementLength - (end - start);
-            Log.info(LogCategory.GENERAL, "moving tag from %d to %d", insertedIndex, insertedIndex + offset);
             insertedIndex += offset;
         }
     }

--- a/src/main/java/io/github/apace100/smwyg/mixin/TextFieldWidgetMixin.java
+++ b/src/main/java/io/github/apace100/smwyg/mixin/TextFieldWidgetMixin.java
@@ -17,10 +17,6 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 @Mixin(TextFieldWidget.class)
 public abstract class TextFieldWidgetMixin implements ItemSharingTextFieldWidget {
-    // TODO: normally, chat messages have whitespace trimmed and collapsed, but sending a tag message bypasses that
-    // TODO: add to message history
-    // TODO: support copying and pasting the tag itself
-
     @Shadow private String text;
 
     private ItemStack itemStack;

--- a/src/main/java/io/github/apace100/smwyg/mixin/TextFieldWidgetMixin.java
+++ b/src/main/java/io/github/apace100/smwyg/mixin/TextFieldWidgetMixin.java
@@ -163,7 +163,7 @@ public abstract class TextFieldWidgetMixin implements ItemSharingTextFieldWidget
         }
 
         if (original > insertedIndex && original < insertedIndex + insertedLength) {
-            return insertedIndex + insertedLength + 1;
+            return insertedIndex + insertedLength;
         } else {
             return original;
         }

--- a/src/main/java/io/github/apace100/smwyg/mixin/TextFieldWidgetMixin.java
+++ b/src/main/java/io/github/apace100/smwyg/mixin/TextFieldWidgetMixin.java
@@ -1,6 +1,8 @@
 package io.github.apace100.smwyg.mixin;
 
 import io.github.apace100.smwyg.duck.ItemSharingTextFieldWidget;
+import net.fabricmc.loader.impl.util.log.Log;
+import net.fabricmc.loader.impl.util.log.LogCategory;
 import net.minecraft.client.gui.widget.TextFieldWidget;
 import net.minecraft.item.ItemStack;
 import net.minecraft.text.Text;
@@ -15,8 +17,12 @@ import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
 
 @Mixin(TextFieldWidget.class)
 public abstract class TextFieldWidgetMixin implements ItemSharingTextFieldWidget {
+    // FIXME: normally, chat messages have whitespace trimmed and collapsed, but sending a tag message bypasses that
+    // FIXME: add to message history
 
     @Shadow private String text;
+    @Shadow private int selectionStart;
+    @Shadow private int selectionEnd;
 
     private ItemStack itemStack;
     private String insertedString;
@@ -38,11 +44,21 @@ public abstract class TextFieldWidgetMixin implements ItemSharingTextFieldWidget
 
     @Override
     public String getTextBefore() {
+        if (insertedIndex < 0 || insertedIndex > this.text.length()) {
+            Log.warn(LogCategory.GENERAL, "Prevented getTextBefore crash with text=%s length=%d insertedIndex=%d", this.text, this.text.length(), insertedIndex);
+            return "";
+        }
+
         return this.text.substring(0, insertedIndex);
     }
 
     @Override
     public String getTextAfter() {
+        if (insertedIndex + insertedLength < 0 || insertedIndex + insertedLength > this.text.length()) {
+            Log.warn(LogCategory.GENERAL, "Prevented getTextAfter crash with text=%s length=%d insertedIndex=%d insertedLength=%d", this.text, this.text.length(), insertedIndex, insertedLength);
+            return "";
+        }
+
         return this.text.substring(insertedIndex + insertedLength);
     }
 
@@ -53,16 +69,25 @@ public abstract class TextFieldWidgetMixin implements ItemSharingTextFieldWidget
 
     @Override
     public void onSuggestionInserted(int start, int offset) {
-        if(this.itemStack != null && start <= insertedIndex) {
+        if (this.hasStack() && start <= insertedIndex) {
             this.insertedIndex += offset;
         }
     }
 
+    @Inject(method = "keyPressed", at = @At("TAIL"))
+    private void logKeyPressed(int keyCode, int scanCode, int modifiers, CallbackInfoReturnable<Boolean> cir) {
+        Log.info(LogCategory.GENERAL, "insertedString=\"%s\" insertedIndex=%d insertedLength=%d", insertedString, insertedIndex, insertedLength);
+    }
+
     @Inject(method = "getCursorPosWithOffset", at = @At("RETURN"), cancellable = true)
     private void modifyCursorOffset(int offset, CallbackInfoReturnable<Integer> cir) {
+        if (!this.hasStack()) {
+            return;
+        }
+
         int original = cir.getReturnValue();
-        if(original > insertedIndex && original < insertedIndex + insertedLength) {
-            if(offset < 0) {
+        if (original > insertedIndex && original < insertedIndex + insertedLength) {
+            if (offset < 0) {
                 cir.setReturnValue(insertedIndex);
             } else {
                 cir.setReturnValue(insertedIndex + insertedLength);
@@ -70,17 +95,47 @@ public abstract class TextFieldWidgetMixin implements ItemSharingTextFieldWidget
         }
     }
 
+    @Inject(method = "getWordSkipPosition", at = @At("RETURN"), cancellable = true)
+    private void modifyWordSkipPosition(int wordOffset, CallbackInfoReturnable<Integer> cir) {
+        if (!this.hasStack()) {
+            return;
+        }
+
+        int original = cir.getReturnValue();
+        if (original > insertedIndex && original < insertedIndex + insertedLength) {
+            if (wordOffset < 0) {
+                cir.setReturnValue(insertedIndex);
+            } else {
+                int skipPos = insertedIndex + insertedLength;
+                // when skipping forwards over a tag, keep going until we hit the beginning of the next word
+                // or the end of the text
+                while (skipPos < this.text.length() && this.text.charAt(skipPos) == ' ') {
+                    ++skipPos;
+                }
+                cir.setReturnValue(skipPos);
+            }
+        }
+    }
+
     @Inject(method = "write", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/TextFieldWidget;setSelectionStart(I)V"), locals = LocalCapture.CAPTURE_FAILHARD)
     private void moveInsertedText(String text, CallbackInfo ci, int i, int j, int k, String string, int l, String string2) {
-        if(i <= insertedIndex && j <= insertedIndex) {
+        if (!this.hasStack()) {
+            return;
+        }
+
+        if (i <= insertedIndex && j <= insertedIndex) {
             this.insertedIndex += l;
         }
     }
 
     @ModifyVariable(method = "setCursor", at = @At("HEAD"), argsOnly = true, ordinal = 0)
     private int modifyCursorSetting(int original) {
-        if(original > insertedIndex && original < insertedIndex + insertedLength) {
-            if(original <= insertedIndex + (insertedLength / 2)) {
+        if (!this.hasStack()) {
+            return original;
+        }
+
+        if (original > insertedIndex && original < insertedIndex + insertedLength) {
+            if (original <= insertedIndex + (insertedLength / 2)) {
                 return insertedIndex;
             } else {
                 return insertedIndex + insertedLength;
@@ -92,35 +147,161 @@ public abstract class TextFieldWidgetMixin implements ItemSharingTextFieldWidget
 
     @ModifyVariable(method = "setSelectionStart", at = @At("HEAD"), argsOnly = true, ordinal = 0)
     private int modifySelectionStart(int original) {
-        if(original > insertedIndex && original < insertedIndex + insertedLength) {
+        if (!this.hasStack()) {
+            return original;
+        }
+
+        if (original > insertedIndex && original < insertedIndex + insertedLength) {
             return insertedIndex;
         } else {
             return original;
-        }
-    }
-
-    @Inject(method = "eraseCharacters", at = @At(value = "INVOKE", target = "Ljava/lang/StringBuilder;<init>(Ljava/lang/String;)V"), locals = LocalCapture.CAPTURE_FAILHARD)
-    private void eraseInsertion(int characterOffset, CallbackInfo ci, int i, int j, int k) {
-        boolean isStartInside = j > insertedIndex && j < insertedIndex + insertedLength;
-        boolean isEndInside = k > insertedIndex && k < insertedIndex + insertedLength;
-        if(isStartInside || isEndInside || (j < insertedIndex && k >= insertedIndex + insertedLength)) {
-            this.itemStack = null;
-            this.insertedLength = 0;
-            this.insertedString = "";
-            this.insertedIndex = 0;
-        } else {
-            if(j <= insertedIndex || k <= insertedIndex) {
-                this.insertedIndex -= (k - j);
-            }
         }
     }
 
     @ModifyVariable(method = "setSelectionEnd", at = @At("HEAD"), argsOnly = true, ordinal = 0)
     private int modifySelectionEnd(int original) {
-        if(original > insertedIndex && original < insertedIndex + insertedLength) {
-            return insertedIndex;
+        if (!this.hasStack()) {
+            return original;
+        }
+
+        if (original > insertedIndex && original < insertedIndex + insertedLength) {
+            return insertedIndex + insertedLength + 1;
         } else {
             return original;
+        }
+    }
+
+    @Inject(method = "eraseCharacters", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/TextFieldWidget;write(Ljava/lang/String;)V"))
+    private void eraseHighlighted(CallbackInfo ci) {
+        if (!this.hasStack()) {
+            return;
+        }
+
+        // handles highlighting backwards and forwards
+        // the range to be deleted is [left,right)
+        int left = Math.min(this.selectionStart, this.selectionEnd);
+        int right = Math.max(this.selectionStart, this.selectionEnd);
+
+        boolean isErasingBefore = left < insertedIndex && right <= insertedIndex;
+
+        // selecting a range inside the tag is not typically possible, but handle it anyway
+        boolean isLeftInside = left > insertedIndex && left < insertedIndex + insertedLength;
+        boolean isRightInside = right > insertedIndex && right < insertedIndex + insertedLength;
+
+        boolean isErasingEntireTag = left <= insertedIndex && right >= insertedIndex + insertedLength;
+
+        Log.info(LogCategory.GENERAL, "ShowMeWhatYouGot: erasing selection. left=%d right=%d", left, right);
+        Log.info(LogCategory.GENERAL, "isErasingBefore=%b isLeftInside=%b isRightInside=%b isErasingEntireTag=%b",
+                isErasingBefore,
+                isLeftInside,
+                isRightInside,
+                isErasingEntireTag
+        );
+
+        if (isLeftInside || isRightInside || isErasingEntireTag) {
+            Log.info(LogCategory.GENERAL,
+                    "ShowMeWhatYouGot: removing tag"
+            );
+            this.itemStack = null;
+            this.insertedLength = 0;
+            this.insertedString = null;
+            this.insertedIndex = 0;
+        } else if (isErasingBefore) {
+            int offset = right - left;
+            Log.info(LogCategory.GENERAL,
+                    "ShowMeWhatYouGot: erasing %d before tag, insertedIndex=%d -> %d",
+                    offset,
+                    this.insertedIndex,
+                    this.insertedIndex - offset
+            );
+            this.insertedIndex -= offset;
+        }
+    }
+
+    @Inject(method = "eraseCharacters", at = @At(value = "INVOKE", target = "Ljava/lang/StringBuilder;<init>(Ljava/lang/String;)V"), locals = LocalCapture.CAPTURE_FAILHARD)
+    private void eraseInsertion(int characterOffset, CallbackInfo ci, int index, int indexStart, int indexEnd) {
+        if (!this.hasStack()) {
+            return;
+        }
+
+        Log.info(LogCategory.GENERAL, "==eraseInsertion==");
+        Log.info(LogCategory.GENERAL, "insertedIndex=%d insertedLength=%d", insertedIndex, insertedLength);
+        Log.info(LogCategory.GENERAL, "index=%d indexStart=%d indexEnd=%d", index, indexStart, indexEnd);
+
+        // erasing inside the tag is not typically possible, but handle it anyway
+        boolean isStartInside = indexStart > insertedIndex && indexStart < insertedIndex + insertedLength;
+        boolean isEndInside = indexEnd > insertedIndex && indexEnd < insertedIndex + insertedLength;
+
+        // It's this check that handles most cases of the tag being erased
+        boolean isErasingTag = indexStart <= insertedIndex && indexEnd >= insertedIndex + insertedLength;
+
+        Log.info(LogCategory.GENERAL, "isStartInside=%b isEndInside=%b isErasingTag=%b", isStartInside, isEndInside, isErasingTag);
+
+        if (isStartInside || isEndInside || isErasingTag) {
+            this.itemStack = null;
+            this.insertedLength = 0;
+            this.insertedString = null;
+            this.insertedIndex = 0;
+            Log.info(LogCategory.GENERAL, "ShowMeWhatYouGot: erasing tag");
+        } else {
+            boolean isErasingBefore = indexStart <= insertedIndex || indexEnd <= insertedIndex;
+            if (isErasingBefore) {
+                int oldIdx = this.insertedIndex;
+                this.insertedIndex -= (indexEnd - indexStart);
+                Log.info(LogCategory.GENERAL, "ShowMeWhatYouGot: shifting tag backwards, %d - %d = %d", oldIdx, indexEnd - indexStart, this.insertedIndex);
+            }
+        }
+    }
+
+    @Inject(method = "charTyped", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/widget/TextFieldWidget;write(Ljava/lang/String;)V"))
+    private void handleHighlightOverwrite(CallbackInfoReturnable<Boolean> cir) {
+        if (!this.hasStack()) {
+            return;
+        }
+
+        // handles highlighting backwards and forwards
+        // the range to be overwritten is [left,right)
+        int left = Math.min(this.selectionStart, this.selectionEnd);
+        int right = Math.max(this.selectionStart, this.selectionEnd);
+
+        if (left == right) {
+            return;
+        }
+
+        boolean isErasingBefore = left < insertedIndex && right <= insertedIndex;
+
+        // selecting a range inside the tag is not typically possible, but handle it anyway
+        boolean isLeftInside = left > insertedIndex && left < insertedIndex + insertedLength;
+        boolean isRightInside = right > insertedIndex && right < insertedIndex + insertedLength;
+
+        boolean isErasingEntireTag = left <= insertedIndex && right >= insertedIndex + insertedLength;
+
+        Log.info(LogCategory.GENERAL, "ShowMeWhatYouGot: overwriting selection. left=%d right=%d", left, right);
+        Log.info(LogCategory.GENERAL, "isErasingBefore=%b isLeftInside=%b isRightInside=%b isErasingEntireTag=%b",
+                isErasingBefore,
+                isLeftInside,
+                isRightInside,
+                isErasingEntireTag
+        );
+
+        if (isLeftInside || isRightInside || isErasingEntireTag) {
+            Log.info(LogCategory.GENERAL,
+                    "ShowMeWhatYouGot: removing tag"
+            );
+            this.itemStack = null;
+            this.insertedLength = 0;
+            this.insertedString = null;
+            this.insertedIndex = 0;
+        } else if (isErasingBefore) {
+            int offset = right - left;
+            Log.info(LogCategory.GENERAL,
+                    "ShowMeWhatYouGot: offset %d before tag, insertedIndex=%d -> %d",
+                    offset,
+                    this.insertedIndex,
+                    this.insertedIndex - offset
+            );
+            this.insertedIndex -= offset;
+            // further index offset of +1 is handled in the write() mixin.
         }
     }
 }

--- a/src/main/java/io/github/apace100/smwyg/mixin/TextFieldWidgetMixin.java
+++ b/src/main/java/io/github/apace100/smwyg/mixin/TextFieldWidgetMixin.java
@@ -169,7 +169,7 @@ public abstract class TextFieldWidgetMixin implements ItemSharingTextFieldWidget
         }
     }
 
-    // all input actions are performed through calls to write(), except for un-highlighted backspace/delete. handle that here.
+    // all input actions are performed through calls to write(), except for backspace/delete when nothing is selected. handle that here.
     @Inject(method = "eraseCharacters", at = @At(value = "INVOKE", target = "Ljava/lang/StringBuilder;<init>(Ljava/lang/String;)V"), locals = LocalCapture.CAPTURE_FAILHARD)
     private void eraseInsertion(int characterOffset, CallbackInfo ci, int index, int start, int end) {
         if (!this.hasStack()) {
@@ -180,7 +180,7 @@ public abstract class TextFieldWidgetMixin implements ItemSharingTextFieldWidget
     }
 
     private void handleOverwrite(int start, int end, int replacementLength) {
-        // when nothing is highlighted, start == end
+        // when no text is selected, start == end
 
         boolean isErasingEntireTag = start <= insertedIndex && end >= insertedIndex + insertedLength;
         // selecting a range inside the tag is not typically possible, but handle it anyway


### PR DESCRIPTION
Closes #6 

This PR fixes the crash caused by off-by-one bug after deleting a tag and then sending the message. It also safeguards against any future similar bug, instead just logging it.

This PR is tested to handle more input use-cases like:
- Delete key
- Ctrl-Backspace
- Ctrl-Delete
- Ctrl-Left/Right (note: e.g. [Dirt] and [Dark Oak Log] are both considered one "word")
- Cut, Paste
- highlight backwards/forwards then backspace/delete/overwrite/cut/paste

However, tabbing through slash-command suggestions multiple times still puts you in an invalid state.

After this, I plan to port this to 1.19, where similar crashes occur.